### PR TITLE
Fixed #62 midi output missing in aubiotrack.

### DIFF
--- a/examples/aubiotrack.c
+++ b/examples/aubiotrack.c
@@ -40,6 +40,18 @@ void process_block(fvec_t * ibuf, fvec_t *obuf) {
   fvec_zeros (obuf);
   if ( is_beat && !is_silence ) {
     aubio_wavetable_play ( wavetable );
+    /* Send tap over midi output */
+    /* Is called without jack use so ask for jack use */
+    if (usejack)
+    {
+       /* Note on midi clock: Midi clock looks like it is more suitable here,
+       * but it is send 24 times between the detected bpm which is impossible
+       * to do since we get here only once per peat.
+       * Therefore midinote is used as a good workaround.
+       * Reference:
+       * http://www.blitter.com/~russtopia/MIDI/~jglatt/tech/midispec/clock.htm */
+      send_noteon(0, 0);
+    }
   } else {
     aubio_wavetable_stop ( wavetable );
   }


### PR DESCRIPTION
I found the time to commit my changes to aubiotrack.
The changes add the missing midi output mentioned in issue #62 . I'd appreciate of you could pull this into aubiotrack.
I've read only a bit about midi and found out there is something called midi beat clock. I wrote the learned stuff in the comment. I think it cannot be used here - just want to mention it there.
Furthermore there might also be a midi off not necessary in some circumstances. If I find the time I'll dig deeper into this or create an issue. (Not relevant for me actually because the program that I use together with aubiotrack generate the missing midi off note)

I've tested this change for about 2 months together with jack2 environment and QLC+ lighting software. I don't have any test programs. I'm not sure if they are needed.

If there are any complains about my changes please let me know. If I need to request pulling into another development path let me know.

Best regards
Tobias
topas-rec