### PR TITLE
help compiler to optimize aubio_pitchyin_do (YIN pitch tracking)

### DIFF
--- a/src/pitch/pitchyin.c
+++ b/src/pitch/pitchyin.c
@@ -127,32 +127,35 @@ aubio_pitchyin_getpitch (const fvec_t * yin)
   return 0;
 }
 
-
 /* all the above in one */
 void
 aubio_pitchyin_do (aubio_pitchyin_t * o, const fvec_t * input, fvec_t * out)
 {
-  smpl_t tol = o->tol;
-  fvec_t *yin = o->yin;
-  uint_t j, tau = 0;
+  const smpl_t tol = o->tol;
+  fvec_t* yin = o->yin;
+  const smpl_t *input_data = input->data;
+  const uint_t length = yin->length;
+  smpl_t *yin_data = yin->data;
+  uint_t j, tau;
   sint_t period;
-  smpl_t tmp = 0., tmp2 = 0.;
-  yin->data[0] = 1.;
-  for (tau = 1; tau < yin->length; tau++) {
-    yin->data[tau] = 0.;
-    for (j = 0; j < yin->length; j++) {
-      tmp = input->data[j] - input->data[j + tau];
-      yin->data[tau] += SQR (tmp);
+  smpl_t tmp, tmp2 = 0.;
+
+  yin_data[0] = 1.;
+  for (tau = 1; tau < length; tau++) {
+    yin_data[tau] = 0.;
+    for (j = 0; j < length; j++) {
+      tmp = input_data[j] - input_data[j + tau];
+      yin_data[tau] += SQR (tmp);
     }
-    tmp2 += yin->data[tau];
+    tmp2 += yin_data[tau];
     if (tmp2 != 0) {
       yin->data[tau] *= tau / tmp2;
     } else {
       yin->data[tau] = 1.;
     }
     period = tau - 3;
-    if (tau > 4 && (yin->data[period] < tol) &&
-        (yin->data[period] < yin->data[period + 1])) {
+    if (tau > 4 && (yin_data[period] < tol) &&
+        (yin_data[period] < yin_data[period + 1])) {
       out->data[0] = fvec_quadratic_peak_pos (yin, period);
       goto beach;
     }


### PR DESCRIPTION
... by giving the compiler a hint that the inner loop arrays (input->data and yin->data) don't change, don't have side-effects, so it can optimize the loops more aggressively. Ideally will vectorize them then. 
Speeds up YIN pitch processing by a factor of ~2x with msvc, "/Ox" . Should have similar results in GCC builds, but I haven't tested this.