### PR TITLE
aubioonset:  user-set MIDI tap note / velocity values.

### DIFF
--- a/doc/aubioonset.txt
+++ b/doc/aubioonset.txt
@@ -9,7 +9,8 @@ SYNOPSIS
              [-O method] [-t thres]
              [-T time-format]
              [-s sil] [-m] [-f]
-             [-j] [-v] [-h]
+             [-j] [-n miditap-note] [-V miditap-velo]
+             [-v] [-h]
 
 DESCRIPTION
 
@@ -69,6 +70,10 @@ OPTIONS
 
   -j, --jack  Use Jack input/output. You will need a Jack connection
   controller to feed aubio some signal and listen to its output.
+
+  -n, --miditap-note  Override note value for MIDI tap. Defaults to 69.
+
+  -V, --miditap-velop  Override velocity value for MIDI tap. Defaults to 65.
 
   -h, --help  Print a short help message and exit.
 

--- a/doc/aubiotrack.txt
+++ b/doc/aubiotrack.txt
@@ -54,6 +54,10 @@ OPTIONS
   -j, --jack  Use Jack input/output. You will need a Jack connection
   controller to feed aubio some signal and listen to its output.
 
+  -n, --miditap-note  Override note value for MIDI tap. Defaults to 69.
+
+  -V, --miditap-velop  Override velocity value for MIDI tap. Defaults to 65.
+
   -T, --timeformat format  Set time format (samples, ms, seconds). Defaults to
   seconds.
 

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -117,6 +117,8 @@ void usage (FILE * stream, int exit_code)
 #endif /* PROG_HAS_OUTPUT */
 #ifdef PROG_HAS_JACK
       "       -j      --jack             use Jack\n"
+      "       -n      --miditap-note     MIDI note\n"
+      "       -V      --miditap-velo     MIDI velocity\n"
 #endif /* PROG_HAS_JACK */
       "       -v      --verbose          be verbose\n"
       "       -h      --help             display this message\n"
@@ -135,7 +137,7 @@ parse_args (int argc, char **argv)
   const char *options = "hv"
     "i:r:B:H:"
 #ifdef PROG_HAS_JACK
-    "j"
+    "jn:V:"
 #endif /* PROG_HAS_JACK */
 #ifdef PROG_HAS_OUTPUT
     "o:"
@@ -164,6 +166,8 @@ parse_args (int argc, char **argv)
     {"hopsize",               1, NULL, 'H'},
 #ifdef PROG_HAS_JACK
     {"jack",                  0, NULL, 'j'},
+    {"miditap-note",          1, NULL, 'n'},
+    {"miditap-velo",          1, NULL, 'V'},
 #endif /* PROG_HAS_JACK */
 #ifdef PROG_HAS_OUTPUT
     {"output",                1, NULL, 'o'},
@@ -206,6 +210,12 @@ parse_args (int argc, char **argv)
         break;
       case 'j':
         usejack = 1;
+        break;
+      case 'n':
+        miditap_note = atoi (optarg);
+        break;
+      case 'V':
+        miditap_velo = atoi (optarg);
         break;
       case 'i':
         source_uri = optarg;


### PR DESCRIPTION
E.g., to map an audio kick drum track onto sampled MIDI drums, where the kick is MIDI note 36, and use a velocity of 80:

```bash
$ aubioonset --miditap-note=36 --miditap-velo=80
```

Ideally, the velocity would be computed somehow from the amplitude of the beat, but that is work for another day.