### PR TITLE
BUGFIX: 'source_wavread' return samples beyond 'data' when there are chunks after it

### DIFF
--- a/src/io/source_wavread.c
+++ b/src/io/source_wavread.c
@@ -432,6 +432,7 @@ uint_t aubio_source_wavread_seek (aubio_source_wavread_t * s, uint_t pos) {
   // reset some values
   s->eof = 0;
   s->read_index = 0;
+  s->read_samples_total = pos;
   return AUBIO_OK;
 }
 


### PR DESCRIPTION
I was wondering why there was some weird audio after transcoding a file with aubio.

Looking at the input WAV bytes, there were extra chunks after 'data' the code would read and return:

![2017-11-26 02_07_11-hexedit - forme - sondag - copy wav](https://user-images.githubusercontent.com/1537591/33236259-9144cb5e-d24e-11e7-8a52-43c4236c0af9.png)
(`r64m` is the next chunk right after 'data')

I've simply tracked the count of samples read, and clamped accordingly, it just works :)