### PR TITLE
Fix build with FFmpeg 4.0

### DIFF
--- a/src/io/source_avcodec.c
+++ b/src/io/source_avcodec.c
@@ -58,7 +58,11 @@
 #include "fmat.h"
 #include "source_avcodec.h"
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 56, 0)
 #define AUBIO_AVCODEC_MAX_BUFFER_SIZE FF_MIN_BUFFER_SIZE
+#else
+#define AUBIO_AVCODEC_MAX_BUFFER_SIZE AV_INPUT_BUFFER_MIN_SIZE
+#endif
 
 struct _aubio_source_avcodec_t {
   uint_t hop_size;


### PR DESCRIPTION
`FF_MIN_BUFFER_SIZE` was removed in FFmpeg 4.0, so use `AV_INPUT_BUFFER_MIN_SIZE` instead.