### PR TITLE
Fix examples failing to send more than one JACK midi event per frame

### DIFF
--- a/examples/utils.c
+++ b/examples/utils.c
@@ -75,8 +75,11 @@ extern void usage (FILE * stream, int exit_code);
 extern int parse_args (int argc, char **argv);
 
 #if HAVE_JACK
+#define MAX_MIDI_EVENTS 128
 aubio_jack_t *jack_setup;
 jack_midi_event_t ev;
+jack_midi_data_t midi_data[MAX_MIDI_EVENTS * 3];
+size_t midi_event_count = 0;
 #endif /* HAVE_JACK */
 
 void examples_common_init (int argc, char **argv);
@@ -128,9 +131,6 @@ void examples_common_init (int argc, char **argv)
 
 void examples_common_del (void)
 {
-#ifdef HAVE_JACK
-  if (ev.buffer) free(ev.buffer);
-#endif
   del_fvec (ibuf);
   del_fvec (obuf);
   aubio_cleanup ();
@@ -147,7 +147,6 @@ void examples_common_process (aubio_process_func_t process_func,
 
 #ifdef HAVE_JACK
     ev.size = 3;
-    ev.buffer = malloc (3 * sizeof (jack_midi_data_t));
     ev.time = 0; // send it now
     debug ("Jack activation ...\n");
     aubio_jack_activate (jack_setup, process_func);
@@ -193,6 +192,10 @@ send_noteon (smpl_t pitch, smpl_t velo)
 {
 #ifdef HAVE_JACK
   if (usejack) {
+    ev.buffer = midi_data + midi_event_count++ * 3;
+    if (midi_event_count >= MAX_MIDI_EVENTS) {
+      midi_event_count = 0;
+    }
     ev.buffer[2] = velo;
     ev.buffer[1] = pitch;
     if (velo == 0) {


### PR DESCRIPTION
Fixes #183. Because send_noteon would always write to the same buffer, successive calls would cause old notes to be overwritten and the same midi message to be sent multiple times until the next frame when the buffer was reallocated. This PR changes it so the messages are always stored in a circular buffer.