### PR TITLE
Added availability of aubio through vcpkg

### DIFF
--- a/doc/requirements.rst
+++ b/doc/requirements.rst
@@ -245,6 +245,8 @@ for ``x86`` using ``msvc 12.0``, use:
 The following `External libraries`_ will be used if found: `libav`_,
 `libsamplerate`_, `libsndfile`_, `libfftw3`_.
 
+Additionally, aubio can be acquired through `vcpkg <https://vcpkg.readthedocs.io/en/latest/examples/installing-and-using-packages/>`_, Microsoft's own package manager for the Windows platform.
+
 iOS
 ...
 


### PR DESCRIPTION
Following #147, this is a much simpler commit, vcpkg documentation has been updated since then and features everything I previously wanted to push as an extra README. i.e. it's just best to redirect the user to their relevant web link instead.