### PR TITLE
Fix typo in musicutils doc

### DIFF
--- a/src/musicutils.h
+++ b/src/musicutils.h
@@ -240,7 +240,7 @@ smpl_t aubio_db_spl (const fvec_t * v);
   \param v vector to get level from
   \param threshold threshold in dB SPL
 
-  \return 0 if level is under the given threshold, 1 otherwise
+  \return 1 if level is under the given threshold, 0 otherwise
 
 */
 uint_t aubio_silence_detection (const fvec_t * v, smpl_t threshold);


### PR DESCRIPTION
This had me spent 20 minutes wondering over my entire logic belief system :smile: 

here https://github.com/aubio/aubio/blob/master/src/mathutils.c#L617

`return (aubio_db_spl (o) < threshold);`

`-15 < -60` returns 0 in C, but in this case the level is above the given threshold. So, I guess the doc should be the other way around.