### PR TITLE
docs: fix simple typo, successfull -> successful

### DIFF
--- a/src/effects/pitchshift.h
+++ b/src/effects/pitchshift.h
@@ -84,7 +84,7 @@ uint_t aubio_pitchshift_get_latency (aubio_pitchshift_t * o);
 
   pitchscale is a frequency ratio. It should be in the range [0.25, 4].
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_pitchshift_set_pitchscale (aubio_pitchshift_t * o,
@@ -105,7 +105,7 @@ smpl_t aubio_pitchshift_get_pitchscale (aubio_pitchshift_t * o);
   \param transpose new pitch transposition of the pitch shifting object,
   expressed in semitones (should be in the range [-24;+24])
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_pitchshift_set_transpose (aubio_pitchshift_t * o,

--- a/src/effects/timestretch.h
+++ b/src/effects/timestretch.h
@@ -123,7 +123,7 @@ uint_t aubio_timestretch_get_samplerate (aubio_timestretch_t * o);
   \param stretch new time stretching ratio of the time stretching object
   (should be in the range [0.025; 10.])
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_timestretch_set_stretch (aubio_timestretch_t * o, smpl_t stretch);
@@ -145,7 +145,7 @@ smpl_t aubio_timestretch_get_stretch (aubio_timestretch_t * o);
 
   pitchscale is a frequency ratio. It should be in the range [0.25, 4].
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_timestretch_set_pitchscale (aubio_timestretch_t * o,
@@ -167,7 +167,7 @@ smpl_t aubio_timestretch_get_pitchscale (aubio_timestretch_t * o);
   \param transpose new pitch transposition of the time stretching object,
   expressed in semitones (should be in the range [-24;+24])
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_timestretch_set_transpose (aubio_timestretch_t * o,

--- a/src/pitch/pitch.h
+++ b/src/pitch/pitch.h
@@ -157,7 +157,7 @@ aubio_pitch_t *new_aubio_pitch (const char_t * method,
 
   mode can be one of "Hz", "midi", "cent", or "bin". Defaults to "Hz".
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_pitch_set_unit (aubio_pitch_t * o, const char_t * mode);
@@ -167,7 +167,7 @@ uint_t aubio_pitch_set_unit (aubio_pitch_t * o, const char_t * mode);
   \param o pitch detection object as returned by new_aubio_pitch()
   \param silence level threshold under which pitch should be ignored, in dB
 
-  \return 0 if successfull, non-zero otherwise
+  \return 0 if successful, non-zero otherwise
 
 */
 uint_t aubio_pitch_set_silence (aubio_pitch_t * o, smpl_t silence);


### PR DESCRIPTION
There is a small typo in src/effects/pitchshift.h, src/effects/timestretch.h, src/pitch/pitch.h.

Should read `successful` rather than `successfull`.

