### PR TITLE
keep note-offs in demo_wav2midi.py

### DIFF
--- a/python/demos/demo_wav2midi.py
+++ b/python/demos/demo_wav2midi.py
@@ -57,7 +57,7 @@ total_frames = 0
 while True:
     samples, read = s()
     new_note = notes_o(samples)
-    if (new_note[0] != 0):
+    if (sum(new_note)>0) and (new_note[0] >= 0):
         note_str = ' '.join(["%.2f" % i for i in new_note])
         print("%.6f" % (total_frames/float(samplerate)), new_note)
         delta = frames2tick(total_frames) - last_time

--- a/python/demos/demo_wav2midi.py
+++ b/python/demos/demo_wav2midi.py
@@ -57,17 +57,17 @@ total_frames = 0
 while True:
     samples, read = s()
     new_note = notes_o(samples)
-    if (sum(new_note)>0) and (new_note[0] >= 0):
+    if ((sum(new_note)>0) and (new_note[0] >= 0) and (new_note[0]<=127)):
         note_str = ' '.join(["%.2f" % i for i in new_note])
         print("%.6f" % (total_frames/float(samplerate)), new_note)
         delta = frames2tick(total_frames) - last_time
-        if new_note[2] > 0:
+        if ((new_note[2] > 0) and (new_note[2]<=127)):
             track.append(Message('note_off', note=int(new_note[2]),
                 velocity=127, time=delta)
                 )
         track.append(Message('note_on',
             note=int(new_note[0]),
-            velocity=int(new_note[1]),
+            velocity=int(min(new_note[1],127)),
             time=delta)
             )
         last_time = frames2tick(total_frames)


### PR DESCRIPTION
thanks for the great library!

I noticed many note off events were filtered by ```demo_wav2midi.py```, resulting in a lot of sustained notes in the MIDI output, so I modified the note filtering condition to include all note off triplets starting with 0.

Also, I added some checks to avoid trying to call ```mido``` with note or velocity values higher than 127, which results in an error.