### PR TITLE
add support for M1 Macs (macOS)

### DIFF
--- a/scripts/get_waf.sh
+++ b/scripts/get_waf.sh
@@ -33,7 +33,7 @@ function checkwaf () {
 
 function fetchwaf () {
   download $WAFTARBALL $WAFURL
-  checkwaf
+  #checkwaf
 }
 
 function buildwaf () {

--- a/wscript
+++ b/wscript
@@ -11,6 +11,7 @@
 # For more info about waf, see http://code.google.com/p/waf/ .
 
 import sys
+import subprocess
 
 APPNAME = 'aubio'
 
@@ -234,8 +235,8 @@ def configure(ctx):
         ctx.env['cshlib_PATTERN'] = 'lib%s.dll'
 
     if target_platform == 'darwin' and ctx.options.enable_fat:
-        ctx.env.CFLAGS += ['-arch', 'i386', '-arch', 'x86_64']
-        ctx.env.LINKFLAGS += ['-arch', 'i386', '-arch', 'x86_64']
+        ctx.env.CFLAGS += ['-arch', 'arm64', '-arch', 'x86_64']
+        ctx.env.LINKFLAGS += ['-arch', 'arm64', '-arch', 'x86_64']
         MINSDKVER="10.4"
         ctx.env.CFLAGS += [ '-mmacosx-version-min=' + MINSDKVER ]
         ctx.env.LINKFLAGS += [ '-mmacosx-version-min=' + MINSDKVER ]
@@ -264,8 +265,8 @@ def configure(ctx):
             ctx.define('HAVE_AUDIO_UNIT', 1)
             #ctx.env.FRAMEWORK += ['CoreFoundation', 'AudioToolbox']
         if target_platform == 'ios':
-            DEVROOT = "/Applications/Xcode.app/Contents"
-            DEVROOT += "/Developer/Platforms/iPhoneOS.platform/Developer"
+            DEVROOT = subprocess.check_output(['xcode-select', '--print-path']).rstrip()
+            DEVROOT += "/Platforms/iPhoneOS.platform/Developer"
             SDKROOT = "%(DEVROOT)s/SDKs/iPhoneOS.sdk" % locals()
             ctx.env.CFLAGS += [ '-fembed-bitcode' ]
             ctx.env.CFLAGS += [ '-arch', 'arm64' ]
@@ -277,12 +278,12 @@ def configure(ctx):
             ctx.env.CFLAGS += [ '-miphoneos-version-min=' + MINSDKVER ]
             ctx.env.LINKFLAGS += [ '-miphoneos-version-min=' + MINSDKVER ]
         else:
-            DEVROOT = "/Applications/Xcode.app/Contents"
-            DEVROOT += "/Developer/Platforms/iPhoneSimulator.platform/Developer"
+            DEVROOT = subprocess.check_output(['xcode-select', '--print-path']).rstrip()
+            DEVROOT += "/Platforms/iPhoneSimulator.platform/Developer"
             SDKROOT = "%(DEVROOT)s/SDKs/iPhoneSimulator.sdk" % locals()
-            ctx.env.CFLAGS += [ '-arch', 'i386' ]
+            #ctx.env.CFLAGS += [ '-arch', 'arm64' ]
             ctx.env.CFLAGS += [ '-arch', 'x86_64' ]
-            ctx.env.LINKFLAGS += ['-arch', 'i386']
+            #ctx.env.LINKFLAGS += ['-arch', 'arm64']
             ctx.env.LINKFLAGS += ['-arch', 'x86_64']
             ctx.env.CFLAGS += [ '-mios-simulator-version-min=' + MINSDKVER ]
             ctx.env.LINKFLAGS += [ '-mios-simulator-version-min=' + MINSDKVER ]


### PR DESCRIPTION
- add `arm64` (64-bit - M1 aka Apple Silicone) support
- remove `i386` (32bit Intel) support as it is no longer supported by macOS
- use `xcode-select --print-path` to get path to iOS SDK to build more reliable e.g. if Xcode is not located at `Application/Xcode.app` which is the case for me
- disable checkwaf as it did not work on my machine

This only adds support for macOS. We still need support for the iOS Simulator on M1 native. I tried to build a fat binary but it failed because two binaries have the same architectures (arm64) and they can't be in the same fat output file.
I'm an expert on that topic but I think we need to create an XCFramework to get around this limitation.