### PR TITLE
specify commit of waf key

### DIFF
--- a/scripts/get_waf.sh
+++ b/scripts/get_waf.sh
@@ -6,7 +6,8 @@ set -e
 WAFVERSION=2.0.21
 WAFTARBALL=waf-$WAFVERSION.tar.bz2
 WAFURL=https://waf.io/$WAFTARBALL
-WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/raw/master/utils/pubkey.asc
+WAFUPSREAMKEYCOMMIT=edde20a6425a5c3eb6b47d5f3f5c4fbc93fed5f4
+WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/raw/$WAFUPSREAMKEYCOMMIT/utils/pubkey.asc
 
 WAFBUILDDIR=`mktemp -d`
 


### PR DESCRIPTION
I had a similar issue to #312, as I was trying to use the latest release, 0.4.9.

To prevent old versions of aubio becoming unusable without manually changing the version of waf set in get_waf.sh, I suggest the commit changing the key be used to download the correct key. This way old versions of aubio will always download the key associated with the version of waf being used.

When waf next change their key (probably around 2025-11-07), WAFUPSTREAMKEYCOMMIT can be set to the new commit.