### PR TITLE
Fix the AUBIO_STRERROR definition under MinGW

### DIFF
--- a/src/aubio_priv.h
+++ b/src/aubio_priv.h
@@ -341,7 +341,7 @@ uint_t aubio_log(sint_t level, const char_t *fmt, ...);
 #define isnan _isnan
 #endif
 
-#if !defined(_MSC_VER)
+#if !defined(_WIN32)
 #define AUBIO_STRERROR(errno,buf,len) strerror_r(errno, buf, len)
 #else
 #define AUBIO_STRERROR(errno,buf,len) strerror_s(buf, len, errno)


### PR DESCRIPTION
I'm compiling aubio under MinGW. The compilation fails with the usage of an undeclared `strerror_r` function.

MinGW defines the `_WIN32` macro, but it does not define `_MSC_VER`. Using `_WIN32` fixes the issue.