### PR TITLE
fix: add '/utf-8' option for msvc compiler to force code page of extension…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ include_dirs = []
 library_dirs = []
 define_macros = [('AUBIO_VERSION', '%s' % __aubio_version__)]
 extra_link_args = []
+extra_compile_args = []
 
 include_dirs += ['python/ext']
 try:
@@ -31,6 +32,9 @@ if sys.platform.startswith('darwin'):
     extra_link_args += ['-framework', 'CoreFoundation',
             '-framework', 'AudioToolbox']
 
+if sys.platform == 'win32':
+    extra_compile_args += [ '/utf-8' ]
+
 sources = sorted(glob.glob(os.path.join('python', 'ext', '*.c')))
 
 aubio_extension = Extension("aubio._aubio",
@@ -38,6 +42,7 @@ aubio_extension = Extension("aubio._aubio",
     include_dirs = include_dirs,
     library_dirs = library_dirs,
     extra_link_args = extra_link_args,
+    extra_compile_args = extra_compile_args,
     define_macros = define_macros)
 
 # TODO: find a way to track if package is built against libaubio


### PR DESCRIPTION
I faced the same problem as #316 in win32 platform.  There maybe some characters in C code have different byte representation between utf8 and locale encoding schema, so forcing msvc compiler use utf8 instead of locale schema to string in extension solve the issue.