### PR TITLE
[waf] bump to 2.0.24

### DIFF
--- a/scripts/get_waf.sh
+++ b/scripts/get_waf.sh
@@ -3,7 +3,7 @@
 set -e
 #set -x
 
-WAFVERSION=2.0.23
+WAFVERSION=2.0.24
 WAFTARBALL=waf-$WAFVERSION.tar.bz2
 WAFURL=https://waf.io/$WAFTARBALL
 WAFUPSTREAMKEY=https://gitlab.com/ita1024/waf/-/raw/waf-$WAFVERSION/utils/pubkey.asc


### PR DESCRIPTION
Waf in latest aubio release doesn't build on the recently released python 3.11, should probably spin a new release as well.