### PR TITLE
Variable bpm

### DIFF
--- a/examples/aubiotrack.c
+++ b/examples/aubiotrack.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
   verbmsg ("threshold: %f\n", onset_threshold);
 
   tempo_out = new_fvec(2);
-  tempo = new_aubio_tempo(tempo_method, buffer_size, hop_size, samplerate);
+  tempo = new_aubio_tempo(tempo_method, buffer_size, hop_size, samplerate, 120.);
   if (tempo == NULL) { ret = 1; goto beach; }
   // set silence threshold very low to output beats even during silence
   // aubio_tempo_set_silence(tempo, -1000.);

--- a/examples/aubiotrack.c
+++ b/examples/aubiotrack.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
   verbmsg ("threshold: %f\n", onset_threshold);
 
   tempo_out = new_fvec(2);
-  tempo = new_aubio_tempo(tempo_method, buffer_size, hop_size, samplerate, 120.);
+  tempo = new_aubio_tempo(tempo_method, buffer_size, hop_size, samplerate, target_bpm);
   if (tempo == NULL) { ret = 1; goto beach; }
   // set silence threshold very low to output beats even during silence
   // aubio_tempo_set_silence(tempo, -1000.);

--- a/examples/parse_args.h
+++ b/examples/parse_args.h
@@ -46,6 +46,7 @@ extern smpl_t pitch_tolerance;
 extern uint_t time_format;
 // tempo stuff
 extern char_t * tempo_method;
+extern smpl_t target_bpm;
 // more general stuff
 extern smpl_t silence_threshold;
 extern smpl_t release_drop;
@@ -97,6 +98,10 @@ void usage (FILE * stream, int exit_code)
       "       -M      --minioi           set minimum inter-onset interval\n"
       "                 a value in second; default=0.012\n"
 #endif /* PROG_HAS_ONSET */
+#ifdef PROG_HAS_TEMPO
+      "       -b      --bpm              set target bpm\n"
+      "                 a value of 15.0 or higher; default=120.0\n"
+#endif
 #ifdef PROG_HAS_PITCH
       "       -p      --pitch            select pitch detection algorithm\n"
       "                 <default|yinfft|yinfast|yin|mcomb|fcomb|schmitt>; default=yinfft\n"
@@ -157,6 +162,9 @@ parse_args (int argc, char **argv)
 #ifdef PROG_HAS_ONSET
     "O:t:M:"
 #endif /* PROG_HAS_ONSET */
+#ifdef PROG_HAS_TEMPO
+    "b:"
+#endif
 #ifdef PROG_HAS_PITCH
     "p:u:l:"
 #endif /* PROG_HAS_PITCH */
@@ -195,6 +203,9 @@ parse_args (int argc, char **argv)
     {"onset-threshold",       1, NULL, 't'},
     {"onset-minioi",          1, NULL, 'M'},
 #endif /* PROG_HAS_ONSET */
+#ifdef PROG_HAS_TEMPO
+    {"bpm",                   1, NULL, 'b'},
+#endif
 #ifdef PROG_HAS_PITCH
     {"pitch",                 1, NULL, 'p'},
     {"pitch-unit",            1, NULL, 'u'},
@@ -267,6 +278,9 @@ parse_args (int argc, char **argv)
         break;
       case 'M':                /* minimum inter-onset-interval */
         onset_minioi = (smpl_t) atof (optarg);
+        break;
+      case 'b':                /* target bpm */
+        target_bpm = (smpl_t) atof (optarg);
         break;
       case 'p':
         pitch_method = optarg;

--- a/examples/utils.c
+++ b/examples/utils.c
@@ -53,6 +53,7 @@ smpl_t pitch_tolerance = 0.0; // will be set if != 0.
 uint_t time_format = 0; // for "seconds", 1 for "ms", 2 for "samples"
 // tempo stuff
 char_t * tempo_method = "default";
+smpl_t target_bpm = 120.0;
 // more general stuff
 smpl_t silence_threshold = -90.;
 smpl_t release_drop = 10.;

--- a/src/aubio.h
+++ b/src/aubio.h
@@ -71,7 +71,7 @@
   // pitch detection
   aubio_pitch_t *pitch = new_aubio_pitch (method, winsize, stepsize, samplerate);
   // beat tracking
-  aubio_tempo_t *tempo = new_aubio_tempo (method, winsize, stepsize, samplerate);
+  aubio_tempo_t *tempo = new_aubio_tempo (method, winsize, stepsize, samplerate, target_bpm);
 
   \endcode
 

--- a/src/tempo/beattracking.c
+++ b/src/tempo/beattracking.c
@@ -386,8 +386,8 @@ aubio_beattracking_checkstate (aubio_beattracking_t * bt)
   /* do some further checks on the final bp value */
 
   // TODO: this might need to depend on the target_bpm instead: bp < 60 / (2*target_bpm)
-  /* if tempo is > 206 bpm, half it */
-  while (0 < bp && bp < 25) {
+  /* if tempo is > ~300 (?) bpm, half it */
+  while (0 < bp && bp < 15) {
 #if AUBIO_BEAT_WARNINGS
     AUBIO_WRN ("doubling from %f (%f bpm) to %f (%f bpm)\n",
         bp, 60.*44100./512./bp, bp/2., 60.*44100./512./bp/2. );

--- a/src/tempo/beattracking.c
+++ b/src/tempo/beattracking.c
@@ -31,6 +31,7 @@ void aubio_beattracking_checkstate (aubio_beattracking_t * bt);
 
 struct _aubio_beattracking_t
 {
+  smpl_t target_bpm;     /** the bpm to target */
   uint_t hop_size;       /** length of one tempo detection function sample, in audio samples */
   uint_t samplerate;     /** samplerate of the original signal */
   fvec_t *rwv;           /** rayleigh weighting for beat period in general model */
@@ -56,13 +57,13 @@ struct _aubio_beattracking_t
 };
 
 aubio_beattracking_t *
-new_aubio_beattracking (uint_t winlen, uint_t hop_size, uint_t samplerate)
+new_aubio_beattracking (uint_t winlen, uint_t hop_size, uint_t samplerate, smpl_t target_bpm)
 {
 
   aubio_beattracking_t *p = AUBIO_NEW (aubio_beattracking_t);
   uint_t i = 0;
-  /* default value for rayleigh weighting - sets preferred tempo to 120bpm */
-  smpl_t rayparam = 60. * samplerate / 120. / hop_size;
+  /* default value for rayleigh weighting - sets preferred tempo to the target_bpm */
+  smpl_t rayparam = 60. * samplerate / target_bpm / hop_size;
   smpl_t dfwvnorm = EXP ((LOG (2.0) / rayparam) * (winlen + 2));
   /* length over which beat period is found [128] */
   uint_t laglen = winlen / 4;
@@ -70,6 +71,7 @@ new_aubio_beattracking (uint_t winlen, uint_t hop_size, uint_t samplerate)
    * 1 onset frame [128] */
   uint_t step = winlen / 4;     /* 1.5 seconds */
 
+  p->target_bpm = target_bpm;
   p->hop_size = hop_size;
   p->samplerate = samplerate;
   p->lastbeat = 0;
@@ -383,6 +385,7 @@ aubio_beattracking_checkstate (aubio_beattracking_t * bt)
 
   /* do some further checks on the final bp value */
 
+  // TODO: this might need to depend on the target_bpm instead: bp < 60 / (2*target_bpm)
   /* if tempo is > 206 bpm, half it */
   while (0 < bp && bp < 25) {
 #if AUBIO_BEAT_WARNINGS

--- a/src/tempo/beattracking.h
+++ b/src/tempo/beattracking.h
@@ -51,10 +51,11 @@ typedef struct _aubio_beattracking_t aubio_beattracking_t;
   \param winlen length of the onset detection window
   \param hop_size number of onset detection samples [512]
   \param samplerate samplerate of the input signal
+  \param target_bpm target bpm
 
 */
 aubio_beattracking_t * new_aubio_beattracking(uint_t winlen, uint_t hop_size,
-    uint_t samplerate);
+    uint_t samplerate, smpl_t target_bpm);
 
 /** track the beat
 

--- a/src/tempo/tempo.c
+++ b/src/tempo/tempo.c
@@ -45,6 +45,7 @@ struct _aubio_tempo_t {
   uint_t winlen;                 /** dfframe bufsize */
   uint_t step;                   /** dfframe hopsize */
   uint_t samplerate;             /** sampling rate of the signal */
+  smpl_t target_bpm;             /** target bpm */
   uint_t hop_size;               /** get hop_size */
   uint_t total_frames;           /** total frames since beginning */
   uint_t last_beat;              /** time of latest detected beat, in samples */
@@ -164,11 +165,12 @@ smpl_t aubio_tempo_get_threshold(aubio_tempo_t * o) {
 
 /* Allocate memory for an tempo detection */
 aubio_tempo_t * new_aubio_tempo (const char_t * tempo_mode,
-    uint_t buf_size, uint_t hop_size, uint_t samplerate)
+    uint_t buf_size, uint_t hop_size, uint_t samplerate, smpl_t target_bpm)
 {
   aubio_tempo_t * o = AUBIO_NEW(aubio_tempo_t);
   char_t specdesc_func[PATH_MAX];
   o->samplerate = samplerate;
+  o->target_bpm = target_bpm;
   // check parameters are valid
   if ((sint_t)hop_size < 1) {
     AUBIO_ERR("tempo: got hop size %d, but can not be < 1\n", hop_size);
@@ -181,6 +183,9 @@ aubio_tempo_t * new_aubio_tempo (const char_t * tempo_mode,
     goto beach;
   } else if ((sint_t)samplerate < 1) {
     AUBIO_ERR("tempo: samplerate (%d) can not be < 1\n", samplerate);
+    goto beach;
+  } else if (target_bpm < 15.) {
+    AUBIO_ERR("tempo: target_bpm (%d) can not be < 15\n", target_bpm);
     goto beach;
   }
 
@@ -209,7 +214,7 @@ aubio_tempo_t * new_aubio_tempo (const char_t * tempo_mode,
   }
   o->od       = new_aubio_specdesc(specdesc_func,buf_size);
   o->of       = new_fvec(1);
-  o->bt       = new_aubio_beattracking(o->winlen, o->hop_size, o->samplerate, 120.);
+  o->bt       = new_aubio_beattracking(o->winlen, o->hop_size, o->samplerate, o->target_bpm);
   o->onset    = new_fvec(1);
   /*if (usedoubled)    {
     o2 = new_aubio_specdesc(type_onset2,buffer_size);

--- a/src/tempo/tempo.c
+++ b/src/tempo/tempo.c
@@ -185,7 +185,7 @@ aubio_tempo_t * new_aubio_tempo (const char_t * tempo_mode,
     AUBIO_ERR("tempo: samplerate (%d) can not be < 1\n", samplerate);
     goto beach;
   } else if (target_bpm < 15.) {
-    AUBIO_ERR("tempo: target_bpm (%d) can not be < 15\n", target_bpm);
+    AUBIO_ERR("tempo: target_bpm (%f) can not be < 15\n", target_bpm);
     goto beach;
   }
 

--- a/src/tempo/tempo.c
+++ b/src/tempo/tempo.c
@@ -209,7 +209,7 @@ aubio_tempo_t * new_aubio_tempo (const char_t * tempo_mode,
   }
   o->od       = new_aubio_specdesc(specdesc_func,buf_size);
   o->of       = new_fvec(1);
-  o->bt       = new_aubio_beattracking(o->winlen, o->hop_size, o->samplerate);
+  o->bt       = new_aubio_beattracking(o->winlen, o->hop_size, o->samplerate, 120.);
   o->onset    = new_fvec(1);
   /*if (usedoubled)    {
     o2 = new_aubio_specdesc(type_onset2,buffer_size);

--- a/src/tempo/tempo.c
+++ b/src/tempo/tempo.c
@@ -191,6 +191,8 @@ aubio_tempo_t * new_aubio_tempo (const char_t * tempo_mode,
 
   /* length of observations, worth about 6 seconds */
   o->winlen = aubio_next_power_of_two(5.8 * samplerate / hop_size);
+  /* for low bpms, double the window size */
+  if (o->target_bpm < 90.) o->winlen = 2 * o->winlen;
   if (o->winlen < 4) o->winlen = 4;
   o->step = o->winlen/4;
   o->blockpos = 0;

--- a/src/tempo/tempo.h
+++ b/src/tempo/tempo.h
@@ -46,12 +46,13 @@ typedef struct _aubio_tempo_t aubio_tempo_t;
   \param buf_size length of FFT
   \param hop_size number of frames between two consecutive runs
   \param samplerate sampling rate of the signal to analyze
+  \param target_bpm target bpm
 
   \return newly created ::aubio_tempo_t if successful, `NULL` otherwise
 
 */
 aubio_tempo_t * new_aubio_tempo (const char_t * method,
-    uint_t buf_size, uint_t hop_size, uint_t samplerate);
+    uint_t buf_size, uint_t hop_size, uint_t samplerate, smpl_t target_bpm);
 
 /** execute tempo detection
 

--- a/tests/src/tempo/test-beattracking.c
+++ b/tests/src/tempo/test-beattracking.c
@@ -11,7 +11,7 @@ int main (void)
   fvec_t * out = new_fvec (win_s / 4); // output beat position
 
   // create beattracking object
-  aubio_beattracking_t * tempo  = new_aubio_beattracking(win_s, 256, 44100);
+  aubio_beattracking_t * tempo  = new_aubio_beattracking(win_s, 256, 44100, 120.);
 
   smpl_t bpm, confidence;
 

--- a/tests/src/tempo/test-tempo.c
+++ b/tests/src/tempo/test-tempo.c
@@ -34,7 +34,7 @@ int main (int argc, char **argv)
 
   // create tempo object
   aubio_tempo_t * o = new_aubio_tempo("default", win_size, hop_size,
-      samplerate);
+      samplerate, 120.);
 
   if (!o) { err = 1; goto beach_tempo; }
 
@@ -76,32 +76,36 @@ int test_wrong_params(void)
   uint_t win_size = 1024;
   uint_t hop_size = 256;
   uint_t samplerate = 44100;
+  smpl_t bpm = 120.;
   aubio_tempo_t *t;
   fvec_t* in, *out;
   uint_t i;
 
   // test wrong method fails
-  if (new_aubio_tempo("undefined", win_size, hop_size, samplerate)) return 1;
+  if (new_aubio_tempo("undefined", win_size, hop_size, samplerate, bpm)) return 1;
 
   // test hop > win fails
-  if (new_aubio_tempo("default", hop_size, win_size, samplerate)) return 1;
+  if (new_aubio_tempo("default", hop_size, win_size, samplerate, bpm)) return 1;
 
   // test null hop_size fails
-  if (new_aubio_tempo("default", win_size, 0, samplerate)) return 1;
+  if (new_aubio_tempo("default", win_size, 0, samplerate, bpm)) return 1;
 
   // test 1 buf_size fails
-  if (new_aubio_tempo("default", 1, 1, samplerate)) return 1;
+  if (new_aubio_tempo("default", 1, 1, samplerate, bpm)) return 1;
 
   // test null samplerate fails
-  if (new_aubio_tempo("default", win_size, hop_size, 0)) return 1;
+  if (new_aubio_tempo("default", win_size, hop_size, 0, bpm)) return 1;
+
+  // test bpm < 15 fails
+  if (new_aubio_tempo("default", win_size, hop_size, samplerate, 14.9)) return 1;
 
   // test short sizes workaround
-  t = new_aubio_tempo("default", 2048, 2048, 500);
+  t = new_aubio_tempo("default", 2048, 2048, 500, bpm);
   if (!t) return 1;
 
   del_aubio_tempo(t);
 
-  t = new_aubio_tempo("default", win_size, hop_size, samplerate);
+  t = new_aubio_tempo("default", win_size, hop_size, samplerate, bpm);
   if (!t) return 1;
 
   in = new_fvec(hop_size);


### PR DESCRIPTION
Aubio has 120 bpm hardcoded in various places. I use it to detect beats in live music to have my lighting synced to the music, which can have a different bpm. Some real-world problems this is trying to address:
- around 80 and around 160 are especially problematic, because it will start flip-flopping between the two
- lower than 80 is completely unusable
- from around 200 and higher it only really detects half of the beats

This PR adds an extra `-b` / `--bpm` command line parameter to set the target bpm. I've been using this for quite some time now, at anything higher than 120 it's fine. I didn't go as low as 15, but 60 works well enough. At ~60 it does appear to sometimes miss a beat (maybe I missed a buffer length somewhere?) but it's still a lot better compared to the bpm being hardcoded at 120.

I only fixed tests enough so that it compiles again.