### PR TITLE
[sink_flac] missing SWAPS definition

### DIFF
--- a/src/io/sink_flac.c
+++ b/src/io/sink_flac.c
@@ -36,6 +36,9 @@
 
 #define MAX_WRITE_SIZE 4096
 
+// swap endian of a short
+#define SWAPS(x) ((x & 0xff) << 8) | ((x & 0xff00) >> 8)
+
 // swap host to little endian
 #if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 #define HTOLES(x) SWAPS(x)


### PR DESCRIPTION
On big endian architecture with libflac enabled the following error would happen when cross-compiling aubio with buildroot.

```
[ 75/243] Linking build/tests/test-pitchshift
/home/autobuild/autobuild/instance-16/output-1/per-package/aubio/host/bin/../lib/gcc/mips64-buildroot-linux-gnu/13.3.0/../../../../mips64-buildroot-linux-gnu/bin/ld: src/libaubio.so: undefined reference to `SWAPS'
collect2: error: ld returned 1 exit status

Waf: Leaving directory `/home/autobuild/autobuild/instance-16/output-1/build/aubio-152d6819b360c2e7b379ee3f373d444ab3df0895/build'
Build failed
```

Indeed there is a missing definition of the `SWAPS` macro in `/src/io/sink_flac.c` file.
This commit copy the `SWAPS` definition from the
`/src/io/sink_wavwrite.c` file in `sink_flac.c` to fix this issue.

The build logs are available here https://autobuild.buildroot.org/?reason=aubio-152d6819b360c2e7b379ee3f373d444ab3df0895